### PR TITLE
Less specific path for riiconnect24.ico

### DIFF
--- a/RiiConnect24-DNS-Server_v1.0.spec
+++ b/RiiConnect24-DNS-Server_v1.0.spec
@@ -29,4 +29,4 @@ exe = EXE(pyz,
           strip=False,
           upx=True,
           runtime_tmpdir=None,
-          console=True , icon='K:\\GitHub\\RiiConnect24-DNS-Server\\riiconnect24.ico')
+          console=True , icon='riiconnect24.ico')


### PR DESCRIPTION
Won't build unless the icon is in that exact location